### PR TITLE
Set up FastAPI-based backend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.venv
+.venv/
+.env
+.DS_Store
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Retailer News
+
+Retailer News is an experimental crawler intended to collect news and analysis about retail topics such as consumer behaviour, e-commerce trends and store design. The current iteration focuses on providing a Python backend that can be extended into a full web application with a separate frontend.
+
+## Project structure
+
+```
+├── data/
+│   └── sites.json        # Editable list of sources and their focus topics
+├── src/
+│   └── retailernews/
+│       ├── api/          # FastAPI application and routes
+│       ├── services/     # Crawler implementation
+│       ├── config.py     # Configuration loading helpers
+│       └── models.py     # Shared Pydantic models
+├── requirements.txt      # Python dependencies
+├── host.json, local.settings.json
+└── README.md
+```
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Run the API locally**
+
+   ```bash
+   uvicorn retailernews.api.app:app --reload
+   ```
+
+   The API exposes the following endpoints:
+
+   - `GET /api/sites`: list configured sources
+   - `POST /api/sites`: add a new source (payload must match `SiteConfig`)
+   - `DELETE /api/sites/{url}`: remove a source using its URL identifier
+   - `POST /api/crawl`: run the crawler across all configured sources
+
+3. **Configure sources**
+
+   Edit `data/sites.json` to add or remove sources. Each entry describes the site name, root URL and the topics you are interested in tracking. The backend can also be pointed to a different configuration file by setting the `RETAILERNEWS_SITES_PATH` environment variable.
+
+## Next steps
+
+- Persist crawl results to Azure storage tables or blobs (dependencies are already in place).
+- Add authentication and scheduling for automatic crawls.
+- Create a dedicated frontend (React, Vue, etc.) that consumes the FastAPI backend.
+- Improve article extraction using site-specific rules or natural language processing.

--- a/data/sites.json
+++ b/data/sites.json
@@ -1,0 +1,14 @@
+{
+  "sites": [
+    {
+      "name": "Retail Dive",
+      "url": "https://www.retaildive.com/",
+      "topics": ["consumer behavior", "e-commerce", "store design"]
+    },
+    {
+      "name": "Practical Ecommerce",
+      "url": "https://www.practicalecommerce.com/",
+      "topics": ["ecommerce trends", "analytics"]
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ lxml
 tldextract
 readability-lxml
 python-dateutil
+fastapi
+uvicorn
+pydantic

--- a/src/retailernews/__init__.py
+++ b/src/retailernews/__init__.py
@@ -1,0 +1,3 @@
+"""Retailer News backend package."""
+
+__all__: list[str] = []

--- a/src/retailernews/api/__init__.py
+++ b/src/retailernews/api/__init__.py
@@ -1,0 +1,3 @@
+"""API surface for Retailer News."""
+
+__all__: list[str] = []

--- a/src/retailernews/api/app.py
+++ b/src/retailernews/api/app.py
@@ -1,0 +1,16 @@
+"""FastAPI application entrypoint."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from retailernews.api.routes import router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Retailer News", description="Retail insights crawler API")
+    app.include_router(router, prefix="/api")
+    return app
+
+
+app = create_app()

--- a/src/retailernews/api/routes.py
+++ b/src/retailernews/api/routes.py
@@ -1,0 +1,50 @@
+"""API routes for the Retailer News backend."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from retailernews.config import AppConfig, SiteConfig
+from retailernews.services.crawler import SiteCrawler
+
+router = APIRouter()
+
+
+def get_config() -> AppConfig:
+    return AppConfig.from_file()
+
+
+def get_crawler() -> SiteCrawler:
+    return SiteCrawler()
+
+
+@router.get("/sites", response_model=list[SiteConfig])
+def list_sites(config: AppConfig = Depends(get_config)) -> list[SiteConfig]:
+    return config.sites
+
+
+@router.post("/sites", response_model=SiteConfig, status_code=201)
+def add_site(site: SiteConfig, config: AppConfig = Depends(get_config)) -> SiteConfig:
+    config.add_site(site)
+    config.dump()
+    return site
+
+
+@router.delete("/sites/{url}", status_code=204)
+def delete_site(url: str, config: AppConfig = Depends(get_config)) -> None:
+    existing = [site for site in config.sites if site.url == url]
+    if not existing:
+        raise HTTPException(status_code=404, detail="Site not found")
+    config.remove_site(url)
+    config.dump()
+
+
+@router.post("/crawl", response_model=list)
+def crawl_all(
+    config: AppConfig = Depends(get_config), crawler: SiteCrawler = Depends(get_crawler)
+) -> list:
+    results = []
+    for site in config.sites:
+        result = crawler.fetch(site)
+        results.append(result.model_dump())
+    return results

--- a/src/retailernews/config.py
+++ b/src/retailernews/config.py
@@ -1,0 +1,58 @@
+"""Application configuration utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+from pydantic import BaseModel, Field
+
+DEFAULT_SITES_PATH = Path(os.getenv("RETAILERNEWS_SITES_PATH", "data/sites.json"))
+
+
+class SiteConfig(BaseModel):
+    """Configuration for a single site to crawl."""
+
+    name: str = Field(..., description="Human readable name of the source")
+    url: str = Field(..., description="Root URL to crawl")
+    topics: List[str] = Field(default_factory=list, description="Topics of interest")
+
+
+class AppConfig(BaseModel):
+    """Top level configuration."""
+
+    sites: List[SiteConfig]
+
+    @classmethod
+    def from_file(cls, path: Path | str | None = None) -> "AppConfig":
+        file_path = Path(path) if path is not None else DEFAULT_SITES_PATH
+        if not file_path.exists():
+            raise FileNotFoundError(f"Site configuration not found at {file_path}")
+
+        with file_path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        sites = data.get("sites", [])
+        return cls(sites=[SiteConfig(**item) for item in sites])
+
+    def dump(self, path: Path | str | None = None) -> None:
+        file_path = Path(path) if path is not None else DEFAULT_SITES_PATH
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"sites": [site.model_dump() for site in self.sites]}
+        with file_path.open("w", encoding="utf-8") as fp:
+            json.dump(payload, fp, indent=2)
+
+    def add_site(self, site: SiteConfig) -> None:
+        self.sites.append(site)
+
+    def remove_site(self, url: str) -> None:
+        self.sites = [site for site in self.sites if site.url != url]
+
+    def iter_topics(self) -> Iterable[str]:
+        seen = set()
+        for site in self.sites:
+            for topic in site.topics:
+                if topic not in seen:
+                    seen.add(topic)
+                    yield topic

--- a/src/retailernews/models.py
+++ b/src/retailernews/models.py
@@ -1,0 +1,26 @@
+"""Domain models used across the application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class Article(BaseModel):
+    """Representation of an extracted article."""
+
+    title: str
+    url: HttpUrl
+    summary: Optional[str] = None
+    published_at: Optional[datetime] = None
+    topics: List[str] = Field(default_factory=list)
+
+
+class CrawlResult(BaseModel):
+    """Result of crawling a single site."""
+
+    source: str
+    articles: List[Article]
+    fetched_at: datetime

--- a/src/retailernews/services/__init__.py
+++ b/src/retailernews/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer implementations for Retailer News."""
+
+from retailernews.services.crawler import SiteCrawler
+
+__all__ = ["SiteCrawler"]

--- a/src/retailernews/services/crawler.py
+++ b/src/retailernews/services/crawler.py
@@ -1,0 +1,68 @@
+"""Simple crawling utilities."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Iterable, List
+
+import requests
+from bs4 import BeautifulSoup
+from readability import Document
+
+from retailernews.config import SiteConfig
+from retailernews.models import Article, CrawlResult
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/119.0.0.0 Safari/537.36"
+)
+
+
+class SiteCrawler:
+    """Crawler capable of extracting article summaries from a site."""
+
+    def __init__(self, timeout: int = 10) -> None:
+        self.timeout = timeout
+
+    def fetch(self, site: SiteConfig) -> CrawlResult:
+        """Fetch the landing page of a site and extract candidate articles."""
+
+        response = requests.get(site.url, headers={"User-Agent": USER_AGENT}, timeout=self.timeout)
+        response.raise_for_status()
+
+        document = Document(response.text)
+        summary_html = document.summary()
+        soup = BeautifulSoup(summary_html, "lxml")
+
+        articles = list(self._extract_articles(soup, site.topics))
+        return CrawlResult(source=site.name, articles=articles, fetched_at=datetime.utcnow())
+
+    def _extract_articles(self, soup: BeautifulSoup, topics: Iterable[str]) -> Iterable[Article]:
+        for link in soup.find_all("a"):
+            title = link.get_text(strip=True)
+            href = link.get("href")
+            if not title or not href:
+                continue
+
+            lower_title = title.lower()
+            matched_topics: List[str] = [topic for topic in topics if topic.lower() in lower_title]
+            summary = self._build_summary(link)
+
+            if matched_topics or summary:
+                try:
+                    article = Article(title=title, url=href, summary=summary, topics=matched_topics)
+                    yield article
+                except Exception as exc:  # pydantic validation error
+                    logger.debug("Skipping article due to validation error: %s", exc)
+
+    def _build_summary(self, link: BeautifulSoup) -> str | None:
+        paragraph = link.find_parent("p")
+        if paragraph:
+            text = paragraph.get_text(strip=True)
+            if text and len(text) > 40:
+                return text
+        return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from retailernews.config import AppConfig, SiteConfig
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    config_path = tmp_path / "sites.json"
+    config = AppConfig(sites=[SiteConfig(name="Test", url="https://example.com", topics=["retail"])])
+    config.dump(config_path)
+
+    loaded = AppConfig.from_file(config_path)
+    assert loaded.sites[0].name == "Test"
+    assert loaded.sites[0].topics == ["retail"]


### PR DESCRIPTION
## Summary
- add a FastAPI-based backend skeleton with configuration, models, and crawling service modules
- provide initial site configuration data, project documentation, and development tooling files
- include a pytest for configuration round-tripping and document local API usage

## Testing
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d24cb2e34883248be875da134cb3a7