### PR TITLE
Add ASGI entrypoint for local development

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+"""ASGI entrypoint for running the Retailer News API with Uvicorn."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the Python path so the retailernews package can be imported
+SRC_PATH = Path(__file__).resolve().parent / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from retailernews.api.app import app  # noqa: E402  (import after path setup)
+
+__all__ = ("app",)


### PR DESCRIPTION
## Summary
- add a top-level ASGI entrypoint module to expose the FastAPI app
- ensure the src directory is added to sys.path before importing the retailernews package

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_b_68d272d7b5f08324ad5eeb413f4f578f