### PR TITLE
Fix HTMLResponse import

### DIFF
--- a/src/retailernews/api/app.py
+++ b/src/retailernews/api/app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
+from starlette.responses import HTMLResponse
 
 from retailernews.api.routes import router
 


### PR DESCRIPTION
## Summary
- import HTMLResponse from starlette.responses to avoid editor resolution errors

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'retailernews')*

------
https://chatgpt.com/codex/tasks/task_b_68d28b6006908324bddaf0518be43857