### PR TITLE
Filter crawler results to same-site URLs

### DIFF
--- a/src/retailernews/services/crawler.py
+++ b/src/retailernews/services/crawler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -45,16 +45,30 @@ class SiteCrawler:
     def _extract_articles(
         self, soup: BeautifulSoup, topics: Iterable[str], site_url: str
     ) -> Iterable[Article]:
+        candidates: List[Tuple[str, str, List[str], BeautifulSoup]] = []
+        seen_urls: set[str] = set()
+
         for link in soup.find_all("a"):
             title = link.get_text(strip=True)
             href = link.get("href")
             if not title or not href:
                 continue
 
+            article_url = urljoin(site_url, href)
+            if not self._is_same_site(site_url, article_url):
+                continue
+
+            if article_url in seen_urls:
+                continue
+
+            seen_urls.add(article_url)
+
             lower_title = title.lower()
             matched_topics: List[str] = [topic for topic in topics if topic.lower() in lower_title]
-            article_url = urljoin(site_url, href)
-            summary = self._build_summary(link, site_url, article_url)
+            candidates.append((title, article_url, matched_topics, link))
+
+        for title, article_url, matched_topics, link in candidates:
+            summary = self._build_summary(link, article_url)
 
             if matched_topics or summary:
                 try:
@@ -68,15 +82,12 @@ class SiteCrawler:
                 except Exception as exc:  # pydantic validation error
                     logger.debug("Skipping article due to validation error: %s", exc)
 
-    def _build_summary(self, link: BeautifulSoup, site_url: str, article_url: str) -> str | None:
+    def _build_summary(self, link: BeautifulSoup, article_url: str) -> str | None:
         paragraph = link.find_parent("p")
         if paragraph:
             text = paragraph.get_text(strip=True)
             if text and len(text) > 40:
                 return text
-
-        if not self._is_same_site(site_url, article_url):
-            return None
 
         try:
             response = requests.get(article_url, headers={"User-Agent": USER_AGENT}, timeout=self.timeout)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+from retailernews.services.crawler import SiteCrawler
+
+
+def test_extract_articles_skips_external_links(monkeypatch) -> None:
+    crawler = SiteCrawler()
+
+    html = """
+    <html>
+        <body>
+            <a href="https://othersite.com/story">External</a>
+            <a href="/news/internal">Internal Story</a>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    monkeypatch.setattr(crawler, "_build_summary", lambda *args, **kwargs: "summary")
+
+    articles = list(crawler._extract_articles(soup, ["Story"], "https://example.com"))
+
+    assert len(articles) == 1
+    assert str(articles[0].url) == "https://example.com/news/internal"


### PR DESCRIPTION
## Summary
- filter extracted article links to only include same-site URLs before creating Article objects
- adjust summary building to rely on the filtered URL list
- add regression test covering the crawler's handling of external links

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_b_68d763869c788324b5b050214007eef4