### PR TITLE
Add article text persistence to crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .env
 .DS_Store
 pytest_cache/
+blobstore/

--- a/src/retailernews/models.py
+++ b/src/retailernews/models.py
@@ -14,6 +14,7 @@ class Article(BaseModel):
     title: str
     url: HttpUrl
     summary: Optional[str] = None
+    text: Optional[str] = None
     published_at: Optional[datetime] = None
     topics: List[str] = Field(default_factory=list)
 


### PR DESCRIPTION
## Summary
- add a text field to the Article model so crawled content includes the full body
- update the crawler to capture article text, persist payloads to blob-style JSON files, and record fetch timestamps
- ignore the generated blobstore directory in source control

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8c31880808324b7065f2ef24d7788