### PR TITLE
Include existing summaries in map_summarize_articles

### DIFF
--- a/src/retailernews/services/summarizer.py
+++ b/src/retailernews/services/summarizer.py
@@ -122,6 +122,19 @@ def map_summarize_articles(blob_root: str = "./blobstore", model: str = "gpt-4o-
     if not root_path.exists():
         return summaries
 
+    summaries_dir = root_path / "summaries"
+    if summaries_dir.exists():
+        for summary_path in summaries_dir.rglob("*.json"):
+            try:
+                with summary_path.open("r", encoding="utf-8") as f:
+                    summary_payload = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            summary_text = summary_payload.get("summary")
+            if summary_text:
+                summaries.append(summary_text)
+
     for article_path in root_path.rglob("*.json"):
         if "summaries" in article_path.parts:
             continue


### PR DESCRIPTION
## Summary
- load existing summary JSON payloads from the summaries directory before creating new ones so previously extracted summaries are returned by map_summarize_articles

## Testing
- pytest *(fails: openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68e4b281f4f08324b872be028caa36e7